### PR TITLE
Integrate Github actions

### DIFF
--- a/.github/PR_template.md
+++ b/.github/PR_template.md
@@ -1,0 +1,7 @@
+---
+title: New release {{payload.release.name}} in the upstream repository {{ payload.repository.name }}.
+---
+The upstream repository just released a new version. Please merge to be up to date.
+
+**Release notes:**
+{{ payload.release.body }}

--- a/.github/PR_template.md
+++ b/.github/PR_template.md
@@ -1,7 +1,7 @@
 ---
 title: New release {{payload.release.name}} in the upstream repository {{ payload.repository.name }}.
 ---
-The upstream repository just released a new version. Please merge to be up to date.
+The CovApp upstream repository just released a new version. Please merge to be up to date.
 
 **Release notes:**
 {{ payload.release.body }}

--- a/.github/workflow/issue_auto_response.yaml
+++ b/.github/workflow/issue_auto_response.yaml
@@ -1,0 +1,19 @@
+name: Issue Autoresponse
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: derekprior/add-autoresponse@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        respondableId: ${{ github.event.issue.node_id }}
+        response: "Thank you for this issue. However, due our limited capacity, we can not respond to issues or pull requests in this repository as we are fully focussed on improving the original qbasic-transpiler."
+        author: ${{ github.event.issue.user.login }}
+        exemptedAuthors: "johnsmith, janedoe"

--- a/.github/workflow/issue_auto_response.yaml
+++ b/.github/workflow/issue_auto_response.yaml
@@ -16,4 +16,3 @@ jobs:
         respondableId: ${{ github.event.issue.node_id }}
         response: "Thank you for opening this issue. Please note that, as we are currently working on solutions to help face the current crisis, we do not have the capacity to responds any issues."
         author: ${{ github.event.issue.user.login }}
-        exemptedAuthors: "johnsmith, janedoe"

--- a/.github/workflow/issue_auto_response.yaml
+++ b/.github/workflow/issue_auto_response.yaml
@@ -14,6 +14,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         respondableId: ${{ github.event.issue.node_id }}
-        response: "Thank you for this issue. However, due our limited capacity, we can not respond to issues or pull requests in this repository as we are fully focussed on improving the original qbasic-transpiler."
+        response: "Thank you for opening this issue. Please note that, as we are currently working on solutions to help face the current crisis, we do not have the capacity to responds any issues."
         author: ${{ github.event.issue.user.login }}
         exemptedAuthors: "johnsmith, janedoe"

--- a/.github/workflow/pull_request_auto_response.yaml
+++ b/.github/workflow/pull_request_auto_response.yaml
@@ -17,4 +17,3 @@ jobs:
         pr-message: "Message that will be displayed on users' first pr. Look, a `code block` for markdown."
         response: "Working on it"
         author: ${{ github.event.pull_request.user.login }}
-        exemptedAuthors: "johnsmith, janedoe"

--- a/.github/workflow/pull_request_auto_response.yaml
+++ b/.github/workflow/pull_request_auto_response.yaml
@@ -14,6 +14,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         respondableId: ${{ github.event.pull_request.node_id }}
-        pr-message: "Message that will be displayed on users' first pr. Look, a `code block` for markdown."
+        pr-message: "Thank you for opening this pull request. Please note that, as we are currently working on solutions to help face the current crisis, we do not have the capacity to manage any pull requests."
         response: "Thank you for opening this pull request. Please note that, as we are currently working on solutions to help face the current crisis, we do not have the capacity to manage any pull requests."
         author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflow/pull_request_auto_response.yaml
+++ b/.github/workflow/pull_request_auto_response.yaml
@@ -1,0 +1,20 @@
+name: Pull Request Autoresponse
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: derekprior/add-autoresponse@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        respondableId: ${{ github.event.pull_request.node_id }}
+        pr-message: "Message that will be displayed on users' first pr. Look, a `code block` for markdown."
+        response: "Working on it"
+        author: ${{ github.event.pull_request.user.login }}
+        exemptedAuthors: "johnsmith, janedoe"

--- a/.github/workflow/pull_request_auto_response.yaml
+++ b/.github/workflow/pull_request_auto_response.yaml
@@ -15,5 +15,5 @@ jobs:
       with:
         respondableId: ${{ github.event.pull_request.node_id }}
         pr-message: "Message that will be displayed on users' first pr. Look, a `code block` for markdown."
-        response: "Working on it"
+        response: "Thank you for opening this pull request. Please note that, as we are currently working on solutions to help face the current crisis, we do not have the capacity to manage any pull requests."
         author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflow/release_sync_pull_requests.yaml
+++ b/.github/workflow/release_sync_pull_requests.yaml
@@ -1,0 +1,17 @@
+name: PRsOnRelease
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  create_PRs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: Gesundheitscloud/github-action-create-synch-PRs-on-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/PR_TEMPLATE.md


### PR DESCRIPTION
Setting up github actions.
* Sync Issues in Forks
  * Action repo is private right now
    * This could potentially solve it https://github.com/marketplace/actions/bagbyte-use-private-action
  * PR_template could be updated
* Create Comment in Issue
  * No template yet? ➡️ #4 
* Create Comment in PR
  * No Template yet? ➡️ #5 

In general we still need to setup a github token as a secret.