### PR TITLE
Move to using non-module JS to improve load performance

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,8 +28,12 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta http-equiv="x-ua-compatible" content="IE=Edge" />
 
+    <!--
+      ESM turns out to be significantly slower for a set of chained request from a small bundle
     <script type="module" src="/build/app.esm.js"></script>
     <script nomodule src="/build/app.js"></script>
+    -->
+    <script src="/build/app.js"></script>
     <link href="/build/app.css" rel="stylesheet" />
 
     <link


### PR DESCRIPTION
Per private conversation with @chaeringer, this removes the module/nomodule loading of covapp to reduce stair-step critical-path JS loading as seen here:

https://www.webpagetest.org/video/compare.php?tests=200419_P3_407999290ab104fafee037f5c4846aea-r%3A2-c%3A0&thumbSize=200&ival=100&end=full

Given the relatively slow TTFB displayed on that timeline (unclear if this is a hosting issue?), I expect this will have a large positive effect.

*NOTE*: this change is only likely to be a net win because the size of the app is so small (~40K of JS post-gzip). Should the app get much larger, would revisit this strategy.